### PR TITLE
MAINT: Fixup `scipy` build

### DIFF
--- a/src/parallel/HighsTaskExecutor.h
+++ b/src/parallel/HighsTaskExecutor.h
@@ -36,8 +36,6 @@ class HighsTaskExecutor {
   };
 
  private:
-  using cache_aligned = highs::cache_aligned;
-
 #ifdef _WIN32
   static HighsSplitDeque*& threadLocalWorkerDeque();
   static ExecutorHandle& threadLocalExecutorHandle();


### PR DESCRIPTION
This reverts commit 619363bb83fb1ea9c76605f63803dfa03dd86a79.

@rgommers, sorry didn't notice this patch was added in the last PR (isn't part of `highs`) and causes a build failure (the variable is already defined publicly).