### PR TITLE
MAINT: declare that `highspy._core` supports free-threaded CPython

### DIFF
--- a/src/highs_bindings.cpp
+++ b/src/highs_bindings.cpp
@@ -638,7 +638,7 @@ HighsStatus highs_setCallback(
         data.ptr());
 }
 
-PYBIND11_MODULE(_core, m) {
+PYBIND11_MODULE(_core, m, py::mod_gil_not_used()) {
   // To keep a smaller diff, for reviewers, the declarations are not moved, but
   // keep in mind:
   // C++ enum classes :: don't need .export_values()


### PR DESCRIPTION
This allows `highspy` to be imported in a free-threaded CPython (see PEP 703) interpreter without raising a warning and re-enabling the GIL. We've tested thread-safety of this extension module reasonably well in SciPy now, and everything seems fine on all tested platforms (Linux, macOS, Windows and x86-64/arm64).

Changes also submitted to upstream: https://github.com/ERGO-Code/HiGHS/pull/2063